### PR TITLE
Fixes/pre existing content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Netlify Status](https://api.netlify.com/api/v1/badges/bcc90532-46e2-43f5-ada4-8163140ed723/deploy-status)](https://app.netlify.com/sites/heuristic-swirles-12e12d/deploys)
+
 # EMBL Design System documentation
 
 The EMBL Design System (EDS) is the laboratory’s design system for communications in all media. The system contains basic information about EMBL branding including colours, typography, and guidelines for the use of the EMBL logo. You will find onboarding tools, design templates and practical resources on the EMBL Design System website. [sitemap here](

--- a/src/site/_includes/layouts/post.njk
+++ b/src/site/_includes/layouts/post.njk
@@ -14,7 +14,9 @@ templateEngineOverride: njk, md
   <div></div>
   <div>
     <h1 class="vf-intro__heading">{{title}}</h1>
+    {% if subtitle %}
     <p class="vf-intro__text">{{subtitle}}</p>
+    {% endif %}
   </div>
 </section>
 

--- a/src/site/brand-guidelines/design-principles.md
+++ b/src/site/brand-guidelines/design-principles.md
@@ -7,8 +7,6 @@ tags: posts
 layout: layouts/post.njk
 ---
 
-# EMBL Design Principles
-
 *Developed in 2019 with close input from EMBL senior scientists*
 
 EMBL needs a strong, overarching brand: EMBL first. If necessary, sub entities such as sites or projects should be expressed after the parent brand  .

--- a/src/site/brand-guidelines/editorial-styleguide.md
+++ b/src/site/brand-guidelines/editorial-styleguide.md
@@ -7,30 +7,6 @@ tags: posts
 layout: layouts/post.njk
 ---
 
-<nav class="vf-navigation vf-navigation--main">
-  <ul class="vf-navigation__list | vf-list--inline">
-    <li class="vf-navigation__item"><a href="/brand-guidelines/design-principles/" class="vf-navigation__link">Design Principles</a></li>
-    <li class="vf-navigation__item"><a href="/brand-guidelines/logo/" class="vf-navigation__link">Logo</a></li>
-    <li class="vf-navigation__item"><a href="/brand-guidelines/editorial-styleguide/" class="vf-navigation__link">Editorial Styleguide</a></li>
-  </ul>
-</nav>
-
-
-<nav class="vf-breadcrumbs" aria-label="Breadcrumb">
-  <ul class="vf-breadcrumbs__list | vf-list vf-list--inline">
-    <li class="vf-breadcrumbs__item">
-      <a href="/" class="vf-breadcrumbs__link">Home</a>
-    </li>
-    <li class="vf-breadcrumbs__item">
-      <a href="/brand-guidelines/" class="vf-breadcrumbs__link">Brand Guidelines</a>
-    </li>
-    <li class="vf-breadcrumbs__item">
-      Editorial Styleguide
-    </li>
-  </ul>
-</nav>
-
-# Editorial Style Guide
 
 The EMBL Editorial Style Guide is intended as a "best-practice" document for writers and editors contributing content in English to EMBL’s communications in all media. It provides clarification on English spelling and points of grammar, as well as brief definitions of technical words and concepts from molecular biology.
 

--- a/src/site/brand-guidelines/logo.md
+++ b/src/site/brand-guidelines/logo.md
@@ -1,15 +1,12 @@
 ---
 title: Logo
-subtitle: subtitle here
+subtitle: Use of the logo
 section: guidelines
 date: 2018-08-22 12:24:50
 tags: posts
 layout: layouts/post.njk
 ---
 
-# The EMBL logo: Overview
-
-Use of the logo
 The EMBL logo is protected under the Paris Convention, which protects names and logos of intergovernmental organisations. You may not use or reproduce the logo without EMBL’s explicit consent.
 
 *Elements of the logo*

--- a/src/site/styles/colour.md
+++ b/src/site/styles/colour.md
@@ -6,7 +6,7 @@ tags: posts
 layout: layouts/post.njk
 ---
 
-<div class="vf-intro__text">The set below shows all the colours for the EMBL brand. Other colours are not allowed. Any kind of colour coding in alignment with a service, group etc. is not allowed. Our main colour is white, in order to underline the bespoke usage of white space in our visual example.</div>
+The set below shows all the colours for the EMBL brand. Other colours are not allowed. Any kind of colour coding in alignment with a service, group etc. is not allowed. Our main colour is white, in order to underline the bespoke usage of white space in our visual example.
 
 
 ## The colour set: Overview

--- a/src/site/styles/typography.md
+++ b/src/site/styles/typography.md
@@ -7,18 +7,6 @@ tags: posts
 layout: layouts/post.njk
 ---
 
-<section class="vf-intro | embl-grid embl-grid--has-centered-content">
-<div><!-- empty --></div>
-<div>
-<h1 class="vf-intro__heading vf-intro__heading--has-tag">Typography<a href="#" class="vf-badge vf-badge--primary vf-badge--phases">Alpha</a></h1>
-<p class="vf-lede">EMBL communications materials and services have broad typographic needs: from rich and engaging editorial content, to information-dense scientific figures and web applications. Any typeface EMBL uses has to be able to work hard to meet these requirements.</p>
-</div>
-</section>
-
-<section class="embl-grid embl-grid--has-centered-content">
-
-<div></div>
-<div class="vf-content">
 
 ### Typeface: IBM Plex
 
@@ -58,19 +46,3 @@ We cannot embed IBM Plex into our distributable Microsoft Office templates such 
 #### Mailchimp
 
 Mailchimp is used for our email newsletter distributions. The template builder includes some webfonts, but not IBM Plex currently. Therefore we are substituting IBM Plex for *Source Sans Pro*.
-
-</div>
-</section>
-
-<section class="embl-grid embl-grid--has-centered-content">
-<div></div>
-<div>
-
-<h3 class="vf-text vf-text--heading-l">Sizes</h3>
-
-{% render '@vf-heading' %}
-
-<p>Lead paragraph</p>
-<p>Paragraph</p>
-</div>
-</section>


### PR DESCRIPTION
this PR:

- fixes some duplicate content because of hard-coded HTML in the `.md` file.
- adds an `if` statement to the `post.njk` so there's no empty `subtitle` HTML if there's no subtitle in the front matter
- adds a netlify badge to this projects repo.

~~to note: certain pages render the HTML in the intro as `code` rather than content. I can't see how it's making this decision or why (I'll raise the issue here, but it could be something with `vf-11ty~~