### PR TITLE
Feature: vf1.x migration

### DIFF
--- a/eleventy.js
+++ b/eleventy.js
@@ -73,11 +73,6 @@ module.exports = function(config) {
   // pass some assets right through
   config.addPassthroughCopy("./src/site/images");
 
-  // copy all component assets, so they're available for developer inspection
-  config.addPassthroughCopy("./src/components");
-  config.addPassthroughCopy("./node_modules/\@visual-framework");
-  // config.addPassthroughCopy({"./node_modules/\@visual-framework": "src/components"});
-
   return {
     dir: {
       input: "src/site",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -91,7 +91,7 @@ let fractalBuildMode = 'build';
 gulp.task('build', gulp.series(
   'vf-clean',
   'copy-design-tokens',
-  gulp.parallel('vf-css','vf-scripts','vf-component-assets'),
+  gulp.parallel('vf-css','vf-css:generate-component-css','vf-scripts','vf-component-assets'),
   'elventy-set-to-build',
   'eleventy'
 ));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -86,12 +86,21 @@ gulp.task('copy-design-tokens', function () {
   .pipe(ext_replace('.ios.json', '.json'))
 });
 
+// A placeholder until vf-core beta.4
+gulp.task('component-compiled-css', function() {
+  return gulp
+    .src([componentPath + '/vf-core-components/**/*.css', componentPath + '/**/*.css'])
+    .pipe(gulp.dest(buildDestionation + '/assets'));
+});
+
+
 // Let's build this sucker.
 let fractalBuildMode = 'build';
 gulp.task('build', gulp.series(
   'vf-clean',
   'copy-design-tokens',
   gulp.parallel('vf-css','vf-css:generate-component-css','vf-scripts','vf-component-assets'),
+  'component-compiled-css',
   'elventy-set-to-build',
   'eleventy'
 ));

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@visual-framework/vf-discussion": "^1.0.0-alpha.6",
     "@visual-framework/vf-divider": "^1.0.0-rc.6",
     "@visual-framework/vf-eleventy--extensions": "^1.0.0-alpha.5",
+    "@visual-framework/vf-font-plex-mono": "^1.0.0-beta.6",
     "@visual-framework/vf-font-plex-sans": "^1.0.0-beta.6",
     "@visual-framework/vf-footer": "^1.0.0-alpha.6",
     "@visual-framework/vf-form__checkbox": "^1.0.0-alpha.6",

--- a/src/components/embl-compatibility-ebivf/README.md
+++ b/src/components/embl-compatibility-ebivf/README.md
@@ -11,6 +11,20 @@ b. wrapping a section of html with the class `.embl-compatibility-ebivf`
 
 ## Install
 
+### Option 1
+
+Use the global VF 2.0 CSS along side your existing VF 1.x CSS; see: https://dev.beta.embl.org/guidelines/design/patterns/
+
+### Option 2
+
+If you don't want to include all the VF 2.0 CSS, add only the compatibility CSS:
+
+```
+https://dev.beta.embl.org/guidelines/design/assets/embl-compatibility-ebivf/assets/embl-compatibility-ebivf.css
+```
+
+### Option 3
+
 This repository is distributed with [npm][npm]. After [installing npm][install-npm], you can install `embl-compatibility-ebivf` with this command.
 
 ```

--- a/src/components/embl-compatibility-ebivf/embl-compatibility-ebivf.css
+++ b/src/components/embl-compatibility-ebivf/embl-compatibility-ebivf.css
@@ -1,0 +1,229 @@
+:root {
+  --vf-color--green: #009f4d;
+  --vf-color--green--darkest: #115740;
+  --vf-color--green--dark: #007a53;
+  --vf-color--green--light: #6cc24a;
+  --vf-color--green--lightest: #d0debb;
+  --vf-color--grey: #707372;
+  --vf-color--grey--darkest: #373a36;
+  --vf-color--grey--dark: #54585a;
+  --vf-color--grey--light: #a8a99e;
+  --vf-color--grey--lightest: #d0d0ce;
+  --vf-color--red: #e40046;
+  --vf-color--red--dark: #a6093d;
+  --vf-color--red--light: #e58f9e;
+  --vf-color--blue: #307fe2;
+  --vf-color--blue--dark: #003da5;
+  --vf-color--blue--light: #8bb8e8;
+  --vf-color--purple: #8246af;
+  --vf-color--purple--dark: #563d82;
+  --vf-color--purple--light: #cba3d8;
+  --vf-color--orange: #ffa300;
+  --vf-color--orange--dark: #be5400;
+  --vf-color--orange--light: #efc06e;
+  --vf-color--yellow: #ffcd00;
+  --vf-color--yellow--dark: #ffb81c;
+  --vf-color--yellow--light: #fdd757;
+  --vf-color--bright-green: #a8c700;
+  --vf-color--bright-green--dark: #84bd00;
+  --vf-color--bright-green--light: #e2e868;
+}
+
+:root {
+  --vf-ui-color--black: #000000;
+  --vf-ui-color--grey: #f3f3f3;
+  --vf-ui-color--grey--light: #d8d8d8;
+  --vf-ui-color--yellow: #fffadc;
+  --vf-ui-color--red: #d32f2f;
+  --vf-ui-color--white: #ffffff;
+  --vf-ui-color--off-white: #fafafa;
+}
+
+/*
+ *
+ * Here lies a set of corrections that make components from VF1 look like VF2, in terms of colour
+ * and typography. So as not to have to make too many 'hacks' in VF2.0
+ *
+ */
+/*!
+ * Component: @visual-framework/embl-compatibility-ebivf
+ * Version: 0.0.1
+ * Location: components/embl-compatibility-ebivf
+ */
+.embl-compatibility-ebivf,
+html body.embl-compatibility-ebivf {
+  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+}
+
+.embl-compatibility-ebivf h1, .embl-compatibility-ebivf .h1, .embl-compatibility-ebivf h2, .embl-compatibility-ebivf .h2, .embl-compatibility-ebivf h3, .embl-compatibility-ebivf .h3, .embl-compatibility-ebivf h4, .embl-compatibility-ebivf .h4, .embl-compatibility-ebivf h5, .embl-compatibility-ebivf .h5, .embl-compatibility-ebivf h6, .embl-compatibility-ebivf .h6,
+html body.embl-compatibility-ebivf h1,
+html body.embl-compatibility-ebivf .h1,
+html body.embl-compatibility-ebivf h2,
+html body.embl-compatibility-ebivf .h2,
+html body.embl-compatibility-ebivf h3,
+html body.embl-compatibility-ebivf .h3,
+html body.embl-compatibility-ebivf h4,
+html body.embl-compatibility-ebivf .h4,
+html body.embl-compatibility-ebivf h5,
+html body.embl-compatibility-ebivf .h5,
+html body.embl-compatibility-ebivf h6,
+html body.embl-compatibility-ebivf .h6 {
+  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+}
+
+body.embl-compatibility-ebivf,
+.embl-compatibility-ebivf p {
+  -webkit-font-smoothing: unset !important;
+  text-rendering: initial;
+}
+
+.embl-compatibility-ebivf h1 {
+  color: unset;
+}
+
+.embl-compatibility-ebivf .masthead-black-bar {
+  background-color: #373a36;
+}
+
+.embl-compatibility-ebivf #masthead-black-bar .row,
+.embl-compatibility-ebivf #global-footer .row {
+  max-width: 76.5rem;
+}
+
+.embl-compatibility-ebivf #global-nav,
+.embl-compatibility-ebivf #global-footer {
+  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+}
+
+.embl-compatibility-ebivf a {
+  border: unset;
+}
+
+.embl-compatibility-ebivf a:hover {
+  text-decoration: unset;
+}
+
+.embl-compatibility-ebivf .vf-button--primary:visited,
+.embl-compatibility-ebivf .vf-button--secondary:visited,
+.embl-compatibility-ebivf .vf-button--tertiary:visited {
+  color: white;
+}
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local("IBM Plex Sans Bold"), local("IBMPlexSans-Bold"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Bold.woff") format("woff");
+}
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: italic;
+  font-weight: 700;
+  src: local("IBM Plex Sans Bold Italic"), local("IBMPlexSans-BoldItalic"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-BoldItalic.woff") format("woff");
+}
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 200;
+  src: local("IBM Plex Sans ExtraLight"), local("IBMPlexSans-ExtraLight"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-ExtraLight.woff") format("woff");
+}
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: italic;
+  font-weight: 200;
+  src: local("IBM Plex Sans ExtraLight Italic"), local("IBMPlexSans-ExtraLightItalic"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-ExtraLightItalic.woff") format("woff");
+}
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: italic;
+  font-weight: 400;
+  src: local("IBM Plex Sans Italic"), local("IBMPlexSans-Italic"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Italic.woff") format("woff");
+}
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 300;
+  src: local("IBM Plex Sans Light"), local("IBMPlexSans-Light"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Light.woff") format("woff");
+}
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: italic;
+  font-weight: 300;
+  src: local("IBM Plex Sans Light Italic"), local("IBMPlexSans-LightItalic"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-LightItalic.woff") format("woff");
+}
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 500;
+  src: local("IBM Plex Sans Medium"), local("IBMPlexSans-Medium"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Medium.woff") format("woff");
+}
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: italic;
+  font-weight: 500;
+  src: local("IBM Plex Sans Medium Italic"), local("IBMPlexSans-MediumItalic"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-MediumItalic.woff") format("woff");
+}
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local("IBM Plex Sans"), local("IBMPlexSans"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff") format("woff");
+}
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 600;
+  src: local("IBM Plex Sans SemiBold"), local("IBMPlexSans-SemiBold"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff") format("woff");
+}
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: italic;
+  font-weight: 600;
+  src: local("IBM Plex Sans SemiBold Italic"), local("IBMPlexSans-SemiBoldItalic"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBoldItalic.woff") format("woff");
+}
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 450;
+  src: local("IBM Plex Sans Text"), local("IBMPlexSans-Text"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Text.woff") format("woff");
+}
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: italic;
+  font-weight: 450;
+  src: local("IBM Plex Sans Text Italic"), local("IBMPlexSans-TextItalic"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-TextItalic.woff") format("woff");
+}
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 100;
+  src: local("IBM Plex Sans Thin"), local("IBMPlexSans-Thin"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Thin.woff") format("woff");
+}
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: italic;
+  font-weight: 100;
+  src: local("IBM Plex Sans Thin Italic"), local("IBMPlexSans-ThinItalic"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-ThinItalic.woff") format("woff");
+}
+
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 400;
+  src: local("IBM Plex Mono"), local("IBMPlexMono"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Mono/fonts/complete/woff/IBMPlexMono-Regular.woff") format("woff");
+}

--- a/src/components/embl-compatibility-ebivf/embl-compatibility-ebivf.scss
+++ b/src/components/embl-compatibility-ebivf/embl-compatibility-ebivf.scss
@@ -31,7 +31,7 @@
 html body.embl-compatibility-ebivf {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
 
-  h1, .h1, h2, .h2, h3, .h3, h4, .h4, h5, .h5, h6, .h6 {
+  h1, .h1, h2, .h2, h3, .h3, h4, .h4, h5, .h5, h6, .h6, p {
     font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
   }
 }

--- a/src/components/embl-compatibility-ebivf/index.scss
+++ b/src/components/embl-compatibility-ebivf/index.scss
@@ -11,5 +11,10 @@
 @import 'embl-compatibility-ebivf.variables.scss';
 @import 'embl-compatibility-ebivf.scss';
 
+// dependencies
+@import 'vf-font-plex-sans/vf-font-plex-sans.scss';
+@import 'vf-font-plex-mono/vf-font-plex-mono.scss';
+
+
 // component variant styles
 // @import 'embl-compatibility-ebivf--variant.scss';

--- a/yarn.lock
+++ b/yarn.lock
@@ -693,6 +693,11 @@
   resolved "https://registry.yarnpkg.com/@visual-framework/vf-figure/-/vf-figure-1.0.0-alpha.6.tgz#0aae5a6b0500628a6034d757fcf2e38beb294d1e"
   integrity sha512-uGeYMi33ql2N/yTpD4Jel5S2YYgkRmJdHe9a0y+AxsIh0+c7TNPEqCOlLUKPuI2zM77hOip46hhvshbwaZBVjA==
 
+"@visual-framework/vf-font-plex-mono@^1.0.0-beta.6":
+  version "1.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@visual-framework/vf-font-plex-mono/-/vf-font-plex-mono-1.0.0-beta.6.tgz#0369a3997da9fbe19e6755be208113c00cd15f89"
+  integrity sha512-c+d3ymuzH8tu2SSzVJ6DcXfIhk7cKdLhKz9ohLFjyBu2y/cJ41ZqsNHd9Jd6Ucw4HAeUZnj2FvoVWr3eAg+RfQ==
+
 "@visual-framework/vf-font-plex-sans@^1.0.0-beta.6":
   version "1.0.0-beta.6"
   resolved "https://registry.yarnpkg.com/@visual-framework/vf-font-plex-sans/-/vf-font-plex-sans-1.0.0-beta.6.tgz#21359ab04fa9b3b9f45da341914a4cdcf3a54436"


### PR DESCRIPTION
When a site needs to use both VF 1.x and 2.0 CSS, allows sites to opt-in to the basic typography (and potentially other cosmetic) easy-wins.